### PR TITLE
Add Error Screen for JSON Parsing

### DIFF
--- a/main/AppContext.cpp
+++ b/main/AppContext.cpp
@@ -1,5 +1,4 @@
 #include "AppContext.h"
-#include <fs/ConfigReader.hpp>
 #include "rapidjson/stringbuffer.h"
 
 #include <memory>

--- a/main/AppContext.h
+++ b/main/AppContext.h
@@ -4,7 +4,7 @@
 #include <mqtt/MQTTGroup.hpp>
 #include <ntp/NTPSync.h>
 #include <wifi/WifiContext.h>
-#include "rapidjson/document.h"
+#include <fs/ConfigReader.hpp>
 #include <memory>
 #include <tuple>
 #include <string>

--- a/main/AppScreen.hpp
+++ b/main/AppScreen.hpp
@@ -29,6 +29,8 @@ class AppScreen : public UIWidget
     template<class N = NavigationDriver>
     void draw(typename std::enable_if<std::is_same<N, gfx::ButtonDriver>::value, N >::type* = 0);
 
+    void showWarning(const std::string warningMessage);
+
     void presentMenu();
     void presentScreen(const uint16_t sceneId);
     void dismissPresentingScreen(const uint16_t tag);

--- a/main/AppScreen.hpp
+++ b/main/AppScreen.hpp
@@ -21,7 +21,8 @@ class AppScreen : public UIWidget
     AppScreen(std::shared_ptr<ctx::AppContext> ctx, Size size = {320, 240});
 
     AppScreen() = default;
-    void setup();
+    void setupScreen();
+    void setupData();
 
     template<class N = NavigationDriver>
     void draw(typename std::enable_if<std::is_same<N, gfx::TouchDriver>::value, N >::type* = 0);

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -80,20 +80,25 @@ namespace gfx
   }
 
   template<class ScreenDriver, class NavigationDriver>
-  void AppScreen<ScreenDriver, NavigationDriver>::setup()
+  void AppScreen<ScreenDriver, NavigationDriver>::setupScreen()
   {
     mTft.begin(320000000);
     mTft.setRotation(Rotation);
     mpStatusBar->setBackgroundColor(Color::BlackColor());
     mpStatusBar->setTextColor(Color::WhiteColor());
+
+    ledcSetup(0, 2000, 8);
+    ledcAttachPin(SDA, 0);
+  }
+
+  template<class ScreenDriver, class NavigationDriver>
+  void AppScreen<ScreenDriver, NavigationDriver>::setupData()
+  {
     mpStatusBar->registerCallback(&mpAppContext->getWifiContext());
     using namespace std::placeholders;
     mpAppContext->getMQTTConnection()->registerConnectionStatusCallback(std::bind(&UIStatusBarWidget::mqttConnectionChanged, mpStatusBar.get(), _1));
 
     presentMenu();
-
-    ledcSetup(0, 2000, 8);
-    ledcAttachPin(SDA, 0);
   }
 
   template<class ScreenDriver, class NavigationDriver>

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -4,6 +4,7 @@
 #include <ui/ScreenNavigator.hpp>
 #include <ui/UIMosaicMenuWidget.hpp>
 #include <ui/UIWidgetBuilder.hpp>
+#include <ui/UIErrorWidget.hpp>
 #include <touch/TouchDriver.h>
 #include <util/varianthelper.hpp>
 
@@ -198,4 +199,15 @@ namespace gfx
     mpStatusBar->setTextLabel("");
   }
 
+  template<class ScreenDriver, class NavigationDriver>
+  void AppScreen<ScreenDriver, NavigationDriver>::showWarning(const std::string warningMessage)
+  {
+    auto frame = Frame();
+    frame.position.x = 0;
+    frame.position.y = 0;
+    frame.size = mWindowSize;
+    auto warningWidget = std::make_shared<UIErrorWidget>(&mTft, frame, 99);
+    warningWidget->setWarningMessage(warningMessage);
+    baseViews.push_back(warningWidget);
+  }
 } // namespace gfx

--- a/main/fs/ConfigReader.hpp
+++ b/main/fs/ConfigReader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <util/warnings.h>
 #include "rapidjson/document.h"
 #include "Filesystem.h"
 #include <mqtt/MQTTConnection.h>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -45,9 +45,10 @@ extern "C"
   void setupApp()
   {
     mpAppContext->setup();
+    mScreen.setupScreen();
     const auto wifiCredentials = fs::ConfigReader::getWifiCredentials();
     mpAppContext->getWifiContext().connect(std::get<0>(wifiCredentials), std::get<1>(wifiCredentials));
-    mScreen.setup();
+    mScreen.setupData();
     mpAppContext->getMQTTConnection()->connect();
   }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -44,8 +44,17 @@ extern "C"
 
   void setupApp()
   {
-    mpAppContext->setup();
     mScreen.setupScreen();
+
+    try
+    {
+      mpAppContext->setup();
+    }
+    catch(const std::exception& e)
+    {
+      mScreen.showWarning(e.what());
+      return;
+    }
     const auto wifiCredentials = fs::ConfigReader::getWifiCredentials();
     mpAppContext->getWifiContext().connect(std::get<0>(wifiCredentials), std::get<1>(wifiCredentials));
     mScreen.setupData();

--- a/main/ui/UIErrorWidget.hpp
+++ b/main/ui/UIErrorWidget.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <ui/UIWidget.hpp>
+#include <string>
+
+namespace gfx
+{
+  struct UIErrorWidget : public UIWidget
+  {
+    UIErrorWidget(ScreenDriver* screenPtr, Frame frame, const uint16_t tag = 0) :
+      UIWidget(screenPtr, frame, tag)
+    {
+      mBackgroundColor = {255, 0, 0};
+    }
+
+    void setWarningMessage(const std::string message)
+    {
+      mWarningMessage = message;
+    }
+
+    void draw() override
+    {
+      mpScreen->createSprite(mFrame, mBackgroundColor);
+      mpScreen->loadFont(SmallFont);
+      mpScreen->setTextColor(Color::WhiteColor(), mBackgroundColor);
+      Frame textFrame;
+      const auto textWidth = mpScreen->getTextWidth(mWarningMessage.c_str());
+      const auto centerPoint = mFrame.getCenterPoint();
+      textFrame.position.x = centerPoint.x - textWidth / 2;
+      textFrame.position.y = mFrame.size.height/2;
+
+      mpScreen->drawText(textFrame, 1, mWarningMessage.c_str());
+      mpScreen->pushSprite(mFrame.position);
+      mpScreen->deleteSprite();
+    }
+
+    private:
+      std::string mWarningMessage;
+  };
+}

--- a/main/util/warnings.h
+++ b/main/util/warnings.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Surround includes in these defines to silence warnings
+// from third party libraries.
+
+#if defined _MSC_VER
+/* DISABLE WARNINGS */
+#define DISABLE_WARNINGS __pragma(warning( push, 0 ))
+/* ENABLE WARNINGS */
+    #define ENABLE_WARNINGS __pragma(warning( pop ))
+#elif defined __GNUC__
+/* DISABLE WARNINGS */
+    #define DISABLE_WARNINGS \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wall\"")
+        _Pragma("GCC diagnostic ignored \"-Wcpp\"")
+/* ENABLE WARNINGS */
+    #define ENABLE_WARNINGS _Pragma("GCC diagnostic push")
+#else  /* TODO: add more compilers here */
+    #define DISABLE_WARNINGS
+    #define ENABLE_WARNINGS
+#endif
+
+#include <exception>
+// Override rapidjson assertions to throw exceptions by default
+#define RAPIDJSON_ASSERT(x) if(!(x)) throw std::logic_error("JSON Parsing failed. Check your config!");


### PR DESCRIPTION
Currently RapidJSON Asserts and crashes.
Redefine the assertion macro to throw instead and display an error message on boot.