### PR TITLE
Improve Multi-Device Scenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This project requires a MQTT-Broker to be running in your smarthome.
 ## Features
 
 + See and trigger scenes (groups of devices) on the front screen.
-+ Trigger individual devices by diving into scenes (long press).
++ Trigger individual devices by diving into scenes (by tapping the indicator or long pressing a button).
++ See partially switched on scenes with multiple devices at a glance.
 + Support for temperature, humidity and air quality sensors.
 + Supports both Touch Screen or Button based navigation.
 + Screen updates automatically when devices are triggered from elsewhere.
@@ -76,7 +77,7 @@ cmake -DM5STACK=ON ../
 ```
   
 Otherwise the default configuration will be for touch-screens like [ArduiTouch](https://www.hwhardsoft.de/english/webshop/arduitouch/) or the widely used ILI9341 like the one offered by [Adafruit](https://www.adafruit.com/product/1770).
-GPIOs for the screen may have to be configured in `main/libraries/TFT_ESPI/User_Setup.h`.  
+GPIOs for the screen as well as M5Stack may have to be configured in `main/libraries/TFT_ESPI/User_Setup.h`.
   
 Other Homepoint specific configuration settings like the time it takes before the Screensaver kicks in can be configured in `main/config/Config.h`.
   

--- a/main/mqtt/MQTTGroup.hpp
+++ b/main/mqtt/MQTTGroup.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mpark/variant.hpp"
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <memory>
@@ -44,6 +45,13 @@ namespace mqtt
     std::function<void()> mSetNeedsUpdateCB;
   };
 
+  enum class MQTTSwitchGroupState
+  {
+    None,
+    Some,
+    All
+  };
+
   struct MQTTSwitchGroup : public MQTTGroup
   {
     bool active = false;
@@ -59,6 +67,25 @@ namespace mqtt
       return true;
     }
 
+    MQTTSwitchGroupState currentState()
+    {
+      auto deviceTest = [](const auto& device)
+      {
+        return device.second.active;
+      };
+
+      if (std::all_of(mDevices.begin(), mDevices.end(), deviceTest))
+      {
+        return MQTTSwitchGroupState::All;
+      }
+
+      if (std::any_of(mDevices.begin(), mDevices.end(), deviceTest))
+      {
+        return MQTTSwitchGroupState::Some;
+      }
+
+      return MQTTSwitchGroupState::None;
+    }
     GroupDevices<MQTTSwitchDevice> mDevices;
   };
 } // namespce mqtt

--- a/main/ui/UIButton.cpp
+++ b/main/ui/UIButton.cpp
@@ -47,6 +47,19 @@ namespace gfx
       const auto activeColor = mIsSelected ? Color::SelectedColor() : mTextColor; 
       mpScreen->setTextColor(activeColor, mBackgroundColor);
       mpScreen->drawText(textFrame, 1, mLabel.c_str());
+
+      if (mHasMoreIndicator)
+      {
+        Frame moreFrame;
+        const std::string moreLabel = "...";
+        const auto textWidth = mpScreen->getTextWidth(moreLabel.c_str());
+        const auto centerPoint = mFrame.getCenterPoint();
+        moreFrame.position.x = mFrame.size.width - textWidth - 13;
+        moreFrame.position.y = 10;
+        mpScreen->loadFont(BoldFont);
+        mpScreen->drawText(moreFrame, 1, moreLabel.c_str());
+      }
+
       mNeedsRedraw = false;
       mpScreen->pushSprite(mFrame.position);
       mpScreen->deleteSprite();
@@ -56,6 +69,11 @@ namespace gfx
   {
     mImagePath = filePath;
     UIWidget::setNeedsRedraw();
+  }
+
+  void UIButton::setMoreIndicator(const bool hasMore)
+  {
+    mHasMoreIndicator = hasMore;
   }
 
   void UIButton::setTextColor(Color textColor)

--- a/main/ui/UIButton.cpp
+++ b/main/ui/UIButton.cpp
@@ -102,16 +102,16 @@ namespace gfx
   {
     if (mFrame.isInBounds(tapEvt.position))
     {
-      switch (tapEvt.state)
+      auto mUpperFrame = mFrame;
+      mUpperFrame.size.height = mUpperFrame.size.height / 2;
+      const auto didTapMoreArea = mUpperFrame.isInBounds(tapEvt.position);
+      if (didTapMoreArea && mHasMoreIndicator)
       {
-        case PressEvent::Tap:
-          callTapAction();
-          break;
-        case PressEvent::LongPress:
-          callLongPressAction();
-          break;
-        default:
-          break;
+        callLongPressAction();
+      }
+      else
+      {
+        callTapAction();
       }
     }
   }

--- a/main/ui/UIButton.h
+++ b/main/ui/UIButton.h
@@ -26,6 +26,7 @@ namespace gfx
     void setTextColor(Color textColor);
     void setImage(const std::string filePath);
     void setLabel(const std::string label);
+    void setMoreIndicator(const bool hasMore);
     void draw() override;
 
     // Touch Driver
@@ -40,6 +41,7 @@ namespace gfx
       Color mTextColor;
       std::string mImagePath;
       std::string mLabel;
+      bool mHasMoreIndicator = false;
       unsigned long mLastTouchEventTime;
       ButtonCallback mButtonCallback;
       ButtonCallback mButtonLongPressCallback;

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -24,6 +24,7 @@ namespace util
       const auto imagePath = ptr->isActive() ? icons.first : icons.second;
       button->setImage(imagePath);
       button->setTextColor(textColor);
+      button->setMoreIndicator(ptr->mDevices.size() > 1);
       auto& context = screen->mpAppContext;
       button->addTargetAction([ptr, context](const uint16_t id) {
         const bool isActive =  ptr->isActive();

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -20,7 +20,11 @@ namespace util
       button->setLabel(ptr->sceneName);
 
       const auto icons = GetIconFileNames(ptr->iconName);
-      const auto textColor = ptr->isActive() ? Color::ActiveBgColor() : Color::InactiveTextColor();
+      const auto state = ptr->currentState();
+      // Switch Textlabel color based on if some or all devices are on.
+      using namespace mqtt;
+      const auto textColor = (state == MQTTSwitchGroupState::Some ||
+        state == MQTTSwitchGroupState::All) ? Color::ActiveBgColor() : Color::InactiveTextColor();
       const auto imagePath = ptr->isActive() ? icons.first : icons.second;
       button->setImage(imagePath);
       button->setTextColor(textColor);
@@ -36,7 +40,12 @@ namespace util
       });
       auto& screenSaver = screen->mScreenSaver; 
       ptr->mSetNeedsUpdateCB = [ptr, weakBtn = std::weak_ptr<UIButton>(button), &screenSaver, icons]() {
-        const auto textColor = ptr->isActive() ? Color::ActiveBgColor() : Color::InactiveTextColor();
+        using namespace mqtt;
+        const auto state = ptr->currentState();
+        // Switch Textlabel color based on if some or all devices are on.
+        const auto textColor = (state == MQTTSwitchGroupState::Some ||
+          state == MQTTSwitchGroupState::All) ? Color::ActiveBgColor() : Color::InactiveTextColor();
+        // Image will only change color when all devices are on.
         const auto imagePath = ptr->isActive() ? icons.first : icons.second;
         auto button = weakBtn.lock();
         if (!button)


### PR DESCRIPTION
Add the following improvements to better support scenes with multiple devices:

- Visually indicate multiple devices inside a scene
- Replace Long-Press with tappable "More Indicator (three dots)" in the upper half
- Visually indicate if some (but not all) devices of a scene are active

Closes: https://github.com/sieren/Homepoint/issues/19

![IMG_5551](https://user-images.githubusercontent.com/5174440/63376460-24b31800-c38e-11e9-8b98-2a0fbf7d0eaf.jpg)
![IMG_5901](https://user-images.githubusercontent.com/5174440/63376469-2ed51680-c38e-11e9-91f0-8298f0614291.jpg)