### PR TITLE
Move to ESP-IDF v4.0 Release Branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   # Get ESP-IDF from github
   - git clone --recursive https://github.com/espressif/esp-idf.git
   - cd esp-idf
-  - git checkout 02f2e63662d0314b689bb4925f5d8efa08cfe033
+  - git checkout release/v4.0
   - git submodule update --init --recursive
   - cd ~
   - python -m pip install --user -r /home/travis/esp/esp-idf/requirements.txt

--- a/README.md
+++ b/README.md
@@ -47,14 +47,12 @@ It has been tested with
 In order to build Homepoint, you need the [ESP-IDF SDK](https://github.com/espressif/esp-idf).
 ### Requirements  
 
-HomePoint was built on ESP-IDF master. Unfortunately CMake Support in 3.3 is incomplete and master is currently changing a lot
-and breaking the dependency to the ESP32-Arduino submodule.  
-I plan to make HomePoint compatible to v4.0 once it gets a public release, for the time being, please 
-use commit `02f2e63662d0314b689bb4925f5d8efa08cfe033` from the ESP-IDF repo.  
+HomePoint was built on ESP-IDF master. Unfortunately CMake Support in v3.3 is incomplete.  
+In order to build HomePoint you need ESP-IDF from the `release/v4.0` branch from the ESP-IDF git repository.  
 
 | Software       | Version                                                                                                                 |
 | :------------- | :----------------------------------------------------------------------------------------------------------------------:|
-|  ESP-IDF       | master (commit [02f2e63662d0314b689bb4925f5d8efa08cfe033](https://github.com/espressif/esp-idf))                                                            |
+|  ESP-IDF       | [release/v4.0](https://github.com/espressif/esp-idf/tree/release/v4.0))                                                            |
 |  Toolchain     | [5.2.0](https://docs.espressif.com/projects/esp-idf/en/stable/get-started-cmake/index.html#step-1-set-up-the-toolchain) |
   
 Installation is fairly straight forward, see [Setting up the Toolchain](https://docs.espressif.com/projects/esp-idf/en/stable/get-started-cmake/index.html#step-1-set-up-the-toolchain) in the Espressif Documentation.  

--- a/main/libraries/TFT_eSPI/User_Setup.h
+++ b/main/libraries/TFT_eSPI/User_Setup.h
@@ -206,6 +206,7 @@
 //#define TFT_DC   27  // Data Command control pin
 //#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
 //#define TFT_BL   32  // LED back-light (required for M5Stack)
+//#define TFT_LED   32  // LED back-light (required for M5Stack)
 
 // ######       EDIT THE PINs BELOW TO SUIT YOUR ESP32 PARALLEL TFT SETUP        ######
 


### PR DESCRIPTION
Move to official ESP-IDF 4.0 release branch.
Since the Arduino ESP32 Component has not been updated yet to work with ESP-IDF 4.0, we are disabling the parts that are currently broken on a separate hack branch.
Once this is resolved, this project will move to the official repo.

Should alleviate concerns such as https://github.com/sieren/Homepoint/issues/22

Closes https://github.com/sieren/Homepoint/issues/23
Breaks https://github.com/sieren/Homepoint/pull/10

