### PR TITLE
Sync NTP every 12 Hours

### DIFF
--- a/main/util/timer.hpp
+++ b/main/util/timer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+#include <chrono>
+#include <future>
+#include <cstdio>
+
+// Very simple Timer utility
+// create thread, let it sleep for given time, then execute task.
+
+class Timer
+{
+public:
+
+  template <typename Time, class callable, class... arguments>
+  static auto async (Time time, callable&& f, arguments&&... args)
+  {
+    std::function<typename std::result_of<callable(arguments...)>::type()> task(std::bind(std::forward<callable>(f),
+      std::forward<arguments>(args)...));
+
+    std::thread([time, task]() {
+          std::this_thread::sleep_for(time);
+          task();
+      }).detach();
+  }
+};


### PR DESCRIPTION
Because of ESP32 Clock Drift we are syncing
with NTP every 12 hours to ensure an accurate time.

Currentl waiting for https://github.com/espressif/esp-idf/issues/3756 to land on `release/v4.0` on `esp-idf.git` (SNTP currently broken)

Closes https://github.com/sieren/Homepoint/issues/21