### PR TITLE
Refactor Configuration into Struct

### DIFF
--- a/main/AppContext.h
+++ b/main/AppContext.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <mqtt/MQTTConnection.h>
-#include <mqtt/MQTTGroup.hpp>
+#include <model/Model.hpp>
 #include <ntp/NTPSync.h>
 #include <wifi/WifiContext.h>
 #include <fs/ConfigReader.hpp>
@@ -16,7 +15,7 @@ namespace ctx
   class AppContext
   {
     public:
-      AppContext();
+      AppContext() = default;
       void setup();
 
       WifiContext& getWifiContext() { return mWifiContext; };
@@ -27,7 +26,7 @@ namespace ctx
       std::shared_ptr<mqtt::MQTTConnection> mpMQTTConnection;
       std::shared_ptr<ntp::NTPSync> mNTPSync;
       WifiContext mWifiContext;
-      std::vector<MQTTVariants> mMQTTGroups;
       rapidjson::Document mConfigDocument;
+      model::Model mModel;
   };
 } // namespace ctx

--- a/main/fs/ConfigReader.hpp
+++ b/main/fs/ConfigReader.hpp
@@ -12,155 +12,155 @@ extern "C"
 
 namespace fs
 {
-  class ConfigReader
-  {
-    public:
-      const model::Model readConfiguration()
-      {
-        model::Model model;
-        using namespace rapidjson;
-        auto config = fs::FileSystem::getInstance().readJsonConfig("/spiffs/config.json");
-        const char* configChar = config.c_str();
-        Document document;
-        document.Parse<0>(configChar);
+class ConfigReader
+{
+  public:
+    const model::Model readConfiguration()
+    {
+      model::Model model;
+      using namespace rapidjson;
+      auto config = fs::FileSystem::getInstance().readJsonConfig("/spiffs/config.json");
+      const char* configChar = config.c_str();
+      Document document;
+      document.Parse<0>(configChar);
 
-        model.mWifiCredentials = ConfigReader::getWifiCredentials(document);
-        model.mTimeZone = getTimeZone(document);
-        model.mMQTTServerConfig = getMQTTConfig(document);
-        model.mMQTTGroups = getMQTTGroups(document);
-        return model;
+      model.mWifiCredentials = ConfigReader::getWifiCredentials(document);
+      model.mTimeZone = getTimeZone(document);
+      model.mMQTTServerConfig = getMQTTConfig(document);
+      model.mMQTTGroups = getMQTTGroups(document);
+      return model;
+    }
+
+  private:
+    const WifiCredentials getWifiCredentials(rapidjson::Document& document)
+    {
+      using namespace rapidjson;
+      Value& apName = document["wifi"];
+      Value& passWd = document["password"];
+      return std::make_tuple(apName.GetString(), passWd.GetString());
+    }
+
+    const std::string getTimeZone(rapidjson::Document& document)
+    {
+      using namespace rapidjson;
+      if (!document.HasMember("timezone"))
+      {
+        return "";
       }
+      Value& timeZone = document["timezone"];
+      return std::string(timeZone.GetString());
+    }
 
-    private:
-      const WifiCredentials getWifiCredentials(rapidjson::Document& document)
-      {
-        using namespace rapidjson;
-        Value& apName = document["wifi"];
-        Value& passWd = document["password"];
-        return std::make_tuple(apName.GetString(), passWd.GetString());
-      }
+    const mqtt::MQTTConfig getMQTTConfig(rapidjson::Document& document)
+    {
+      mqtt::MQTTConfig conf;
+      using namespace rapidjson;
+      Value& ipAddr = document["mqttbroker"];
+      Value& mqttusername = document["mqttusername"];
+      Value& mqttpasswd = document["mqttpasswd"];
+      conf.credentials = std::make_tuple(mqttusername.GetString(), mqttpasswd.GetString());
+      conf.addr = ipAddr.GetString();
+      return conf;
+    }
 
-      const std::string getTimeZone(rapidjson::Document& document)
+    static std::vector<MQTTVariants> getMQTTGroups(rapidjson::Document& document)
+    {
+      using namespace rapidjson;
+      using namespace mqtt;
+
+      uint16_t tagId = 0;
+      const auto& scenes = document["scenes"].GetArray();
+      std::vector<MQTTVariants> vecScenes;
+      for (const auto& scene : scenes)
       {
-        using namespace rapidjson;
-        if (!document.HasMember("timezone"))
+        if (std::string(scene["type"].GetString()) == "Light" ||
+            std::string(scene["type"].GetString()) == "Switch")
         {
-          return "";
+          auto aScene = std::make_shared<MQTTSwitchGroup>();
+          aScene->sceneName = scene["name"].GetString();
+          aScene->iconName = scene["icon"].GetString();
+          GroupDevices<MQTTSwitchDevice> devices;
+          int deviceId = 0;
+          for (const auto& device : scene["devices"].GetArray())
+          {
+            MQTTSwitchDevice switchDevice;
+            switchDevice.deviceId = deviceId;
+            switchDevice.name = device["name"].GetString();
+            switchDevice.getTopic = device["getTopic"].GetString();
+            switchDevice.setTopic = device["setTopic"].GetString();
+            switchDevice.onValue = device["onValue"].GetString();
+            switchDevice.offValue = device["offValue"].GetString();
+            devices.push_back({switchDevice.getTopic, std::move(switchDevice)});
+            deviceId += 1;
+          }
+          aScene->mDevices = devices;
+          aScene->groupId = tagId;
+          MQTTVariants variant = aScene;
+          vecScenes.push_back(aScene);
         }
-        Value& timeZone = document["timezone"];
-        return std::string(timeZone.GetString());
-      }
-
-      const mqtt::MQTTConfig getMQTTConfig(rapidjson::Document& document)
-      {
-        mqtt::MQTTConfig conf;
-        using namespace rapidjson;
-        Value& ipAddr = document["mqttbroker"];
-        Value& mqttusername = document["mqttusername"];
-        Value& mqttpasswd = document["mqttpasswd"];
-        conf.credentials = std::make_tuple(mqttusername.GetString(), mqttpasswd.GetString());
-        conf.addr = ipAddr.GetString();
-        return conf;
-      }
-
-      static std::vector<MQTTVariants> getMQTTGroups(rapidjson::Document& document)
-      {
-        using namespace rapidjson;
-        using namespace mqtt;
-
-        uint16_t tagId = 0;
-        const auto& scenes = document["scenes"].GetArray();
-        std::vector<MQTTVariants> vecScenes;
-        for (const auto& scene : scenes)
+        else if (std::string(scene["type"].GetString()) == "Sensor")
         {
-          if (std::string(scene["type"].GetString()) == "Light" ||
-              std::string(scene["type"].GetString()) == "Switch")
+          auto aScene = std::make_shared<MQTTSensorGroup>();
+          aScene->sceneName = scene["name"].GetString();
+          aScene->iconName = scene["icon"].GetString();
+          GroupDevices<MQTTSensorDevice> devices;
+          int deviceId = 0;
+          for (const auto& device : scene["devices"].GetArray())
           {
-            auto aScene = std::make_shared<MQTTSwitchGroup>();
-            aScene->sceneName = scene["name"].GetString();
-            aScene->iconName = scene["icon"].GetString();
-            GroupDevices<MQTTSwitchDevice> devices;
-            int deviceId = 0;
-            for (const auto& device : scene["devices"].GetArray())
+            MQTTSensorDevice sensorDevice;
+            sensorDevice.deviceId = deviceId;
+            const auto sensorType = mqtt::util::GetSensorType(std::string(device["type"].GetString()));
+            if (sensorType == MQTTSensorType::MQTTINVALID)
             {
-              MQTTSwitchDevice switchDevice;
-              switchDevice.deviceId = deviceId;
-              switchDevice.name = device["name"].GetString();
-              switchDevice.getTopic = device["getTopic"].GetString();
-              switchDevice.setTopic = device["setTopic"].GetString();
-              switchDevice.onValue = device["onValue"].GetString();
-              switchDevice.offValue = device["offValue"].GetString();
-              devices.push_back({switchDevice.getTopic, std::move(switchDevice)});
-              deviceId += 1;
+              ESP_LOGI("CONFIG READER", "Unknown Sensor Type detected");
+              abort();
             }
-            aScene->mDevices = devices;
-            aScene->groupId = tagId;
-            MQTTVariants variant = aScene;
-            vecScenes.push_back(aScene);
-          }
-          else if (std::string(scene["type"].GetString()) == "Sensor")
-          {
-            auto aScene = std::make_shared<MQTTSensorGroup>();
-            aScene->sceneName = scene["name"].GetString();
-            aScene->iconName = scene["icon"].GetString();
-            GroupDevices<MQTTSensorDevice> devices;
-            int deviceId = 0;
-            for (const auto& device : scene["devices"].GetArray())
+            sensorDevice.sensorType = sensorType;
+
+            sensorDevice.dataType = MQTTSensorDataType::Raw;
+
+            if (device.HasMember("jsondata"))
             {
-              MQTTSensorDevice sensorDevice;
-              sensorDevice.deviceId = deviceId;
-              const auto sensorType = mqtt::util::GetSensorType(std::string(device["type"].GetString()));
-              if (sensorType == MQTTSensorType::MQTTINVALID)
-              {
-                ESP_LOGI("CONFIG READER", "Unknown Sensor Type detected");
-                abort();
-              }
-              sensorDevice.sensorType = sensorType;
-
-              sensorDevice.dataType = MQTTSensorDataType::Raw;
-              
-              if (device.HasMember("jsondata"))
-              {
-                sensorDevice.dataType = device["jsondata"].GetBool() ? MQTTSensorDataType::JSON : MQTTSensorDataType::Raw;
-              }
-
-              if (sensorDevice.dataType == MQTTSensorDataType::JSON)
-              {
-                std::vector<ValueTuple> vals;
-                if (sensorDevice.sensorType == MQTTSensorType::MQTTTemperatureHumidity)
-                {
-                  ValueTuple temperatureTuple {MQTTTemperatureKeyJSON, std::string(device[MQTTTemperatureKeyJSON.c_str()].GetString()), std::string("0")};
-                  ValueTuple humidityTuple {MQTTHumidityKeyJSON, std::string(device[MQTTHumidityKeyJSON.c_str()].GetString()), std::string("0")};
-                  vals.push_back(std::move(temperatureTuple));
-                  vals.push_back(std::move(humidityTuple));
-                  if (std::distance(scene["devices"].GetArray().begin(), scene["devices"].GetArray().end()) > 1)
-                  {
-                    ESP_LOGI("CONFIG READER", "Only one Temperature Humidty JSON Device per Scene allowed");
-                    abort();
-                  }
-                }
-                else
-                {
-                  const auto sensorType = MQTTSensorTypeJSONKey(sensorDevice.sensorType);
-                  ValueTuple mappedValues {sensorType, std::string(device[sensorType.c_str()].GetString()), std::string("0")};
-                  vals.push_back(std::move(mappedValues));
-                }
-                sensorDevice.mappedValues = vals;
-              }
-              sensorDevice.name = device["name"].GetString();
-              sensorDevice.getTopic = device["getTopic"].GetString();
-              devices.push_back({sensorDevice.getTopic, std::move(sensorDevice)});
-              deviceId += 1;
+              sensorDevice.dataType = device["jsondata"].GetBool() ? MQTTSensorDataType::JSON : MQTTSensorDataType::Raw;
             }
-            aScene->mSensorDevices = devices;
-            aScene->groupId = tagId;
-            MQTTVariants variant = aScene;
-            vecScenes.push_back(aScene);
+
+            if (sensorDevice.dataType == MQTTSensorDataType::JSON)
+            {
+              std::vector<ValueTuple> vals;
+              if (sensorDevice.sensorType == MQTTSensorType::MQTTTemperatureHumidity)
+              {
+                ValueTuple temperatureTuple {MQTTTemperatureKeyJSON, std::string(device[MQTTTemperatureKeyJSON.c_str()].GetString()), std::string("0")};
+                ValueTuple humidityTuple {MQTTHumidityKeyJSON, std::string(device[MQTTHumidityKeyJSON.c_str()].GetString()), std::string("0")};
+                vals.push_back(std::move(temperatureTuple));
+                vals.push_back(std::move(humidityTuple));
+                if (std::distance(scene["devices"].GetArray().begin(), scene["devices"].GetArray().end()) > 1)
+                {
+                  ESP_LOGI("CONFIG READER", "Only one Temperature Humidty JSON Device per Scene allowed");
+                  abort();
+                }
+              }
+              else
+              {
+                const auto sensorType = MQTTSensorTypeJSONKey(sensorDevice.sensorType);
+                ValueTuple mappedValues {sensorType, std::string(device[sensorType.c_str()].GetString()), std::string("0")};
+                vals.push_back(std::move(mappedValues));
+              }
+              sensorDevice.mappedValues = vals;
+            }
+            sensorDevice.name = device["name"].GetString();
+            sensorDevice.getTopic = device["getTopic"].GetString();
+            devices.push_back({sensorDevice.getTopic, std::move(sensorDevice)});
+            deviceId += 1;
           }
-          tagId += 1;
+          aScene->mSensorDevices = devices;
+          aScene->groupId = tagId;
+          MQTTVariants variant = aScene;
+          vecScenes.push_back(aScene);
         }
-        return vecScenes;
+        tagId += 1;
       }
+      return vecScenes;
+    }
 
-  };
+};
 } // namespace fs

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -56,8 +56,6 @@ extern "C"
       return;
     }
     mScreen.showWarning("Loading Screen");
-    const auto wifiCredentials = fs::ConfigReader::getWifiCredentials();
-    mpAppContext->getWifiContext().connect(std::get<0>(wifiCredentials), std::get<1>(wifiCredentials));
     mScreen.setupData();
     mpAppContext->getMQTTConnection()->connect();
   }

--- a/main/model/Model.hpp
+++ b/main/model/Model.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mqtt/MQTTConnection.h>
+#include <mqtt/MQTTGroup.hpp>
+#include <mqtt/MQTTSensorGroup.hpp>
+
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using WifiCredentials = std::tuple<std::string, std::string>;
+
+namespace model
+{
+struct Model
+{
+  WifiCredentials mWifiCredentials;
+  std::string mTimeZone;
+  mqtt::MQTTConfig mMQTTServerConfig;
+  std::vector<MQTTVariants> mMQTTGroups;
+};
+} // namespace model


### PR DESCRIPTION
Instead of repeatedely reading the configuration, this now
happens once and we store the configuration in a struct
in memory permanently.

Closes https://github.com/sieren/Homepoint/issues/27