### PR TITLE
Refactor Wifi Connection

### DIFF
--- a/main/AppContext.h
+++ b/main/AppContext.h
@@ -21,6 +21,7 @@ namespace ctx
       WifiContext& getWifiContext() { return mWifiContext; };
       std::shared_ptr<mqtt::MQTTConnection> getMQTTConnection() { return mpMQTTConnection; };
       std::vector<MQTTVariants> &getMQTTGroups();
+      void connectionStateChanged(ctx::WifiConnectionState state);
 
     private: 
       std::shared_ptr<mqtt::MQTTConnection> mpMQTTConnection;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -57,7 +57,6 @@ extern "C"
     }
     mScreen.showWarning("Loading Screen");
     mScreen.setupData();
-    mpAppContext->getMQTTConnection()->connect();
   }
 
   void runLoop(void *pvParameters)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -62,9 +62,11 @@ extern "C"
 
   void runLoop(void *pvParameters)
   {
-    for(;;) {
-        if(loopTaskWDTEnabled){
-            esp_task_wdt_reset();
+    for(;;)
+    {
+        if (loopTaskWDTEnabled)
+        {
+          esp_task_wdt_reset();
         }
         mScreen.draw();
         delay(50);

--- a/main/ui/UIStatusBarWidget.cpp
+++ b/main/ui/UIStatusBarWidget.cpp
@@ -11,7 +11,7 @@ namespace gfx
   UIStatusBarWidget::UIStatusBarWidget(ScreenDriver* screenptr, Frame frame, uint16_t tag) :
     UIWidget(screenptr, frame, tag)
     {
-      mLastUpdate = std::chrono::system_clock::now();
+      mLastUpdate = std::chrono::system_clock::now() - std::chrono::seconds(StatusBarUpdateInterval);
     }
   
   void UIStatusBarWidget::wifiChanged(ctx::WifiConnectionState connectionState)
@@ -31,6 +31,7 @@ namespace gfx
         break;
       case WifiAssociationState::DISCONNECTED:
         mIpAddressLabel = "DISCONNECTED";
+        mWifiImage = "wifi_off";
         break;
     }
     mNeedsRedraw = true;

--- a/main/wifi/WifiContext.cpp
+++ b/main/wifi/WifiContext.cpp
@@ -35,20 +35,14 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         esp_wifi_connect();
         callback(ctx::WifiAssociationState::CONNECTING);
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-        if (s_retry_num < 3) {
-            esp_wifi_connect();
-            xEventGroupClearBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
-            s_retry_num++;
-            ESP_LOGI(TAG, "retry to connect to the AP");
-            callback(ctx::WifiAssociationState::CONNECTING);
-        }
-        ESP_LOGI(TAG,"connect to the AP fail");
-        callback(ctx::WifiAssociationState::DISCONNECTED);
+        esp_wifi_connect();
+        xEventGroupClearBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+        ESP_LOGI(TAG, "retry to connect to the AP");
+        callback(ctx::WifiAssociationState::CONNECTING);
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
         ESP_LOGI(TAG, "got ip:%s",
                  ip4addr_ntoa(&event->ip_info.ip));
-        s_retry_num = 0;
         xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
         callback(ctx::WifiAssociationState::CONNECTED);
     }


### PR DESCRIPTION
Refactor Wifi Connection handling:
- Try connecting to MQTT only AFTER we have established a connection
- Continuously try to connect to Wifi instead of just attempting to connect 3 times.
This also solves an issue where Homepoint won't reconnect after Wifi went down.