### PR TITLE
Alternative between Time and IP Address

### DIFF
--- a/main/ui/UIStatusBarWidget.cpp
+++ b/main/ui/UIStatusBarWidget.cpp
@@ -61,6 +61,7 @@ namespace gfx
     {
       mLastUpdate = std::chrono::system_clock::now();
       mNeedsRedraw = true;
+      mIsWifiDisplayed = !mIsWifiDisplayed;
     }
     if (mNeedsRedraw == false) 
     {
@@ -78,7 +79,8 @@ namespace gfx
     mpScreen->drawJpg(util::GetIconFilePath(mMqttImage), mMqttImageFrame.position);
 
     auto textLabelFrame = mFrame;
-    const auto textLabel = mTextLabel == "" ? ntp::util::GetCurrentTime() : mTextLabel;
+    const auto timeIpAddrLabel = mIsWifiDisplayed ? mIpAddressLabel : ntp::util::GetCurrentTime();
+    const auto textLabel = mTextLabel == "" ? timeIpAddrLabel : mTextLabel;
     const auto textWidth = mpScreen->getTextWidth(textLabel.c_str());
     const auto centerPoint = mFrame.getCenterPoint();
     textLabelFrame.position.x = centerPoint.x - textWidth / 2;

--- a/main/ui/UIStatusBarWidget.h
+++ b/main/ui/UIStatusBarWidget.h
@@ -32,5 +32,6 @@ namespace gfx
       std::string mTimeLabel = "0:00";
       std::string mTextLabel = "";
       std::chrono::system_clock::time_point mLastUpdate;
+      bool mIsWifiDisplayed = false;
   };
 } // namespace gfx


### PR DESCRIPTION
Alternate between Time and IP Address in 4 second
intervals so users can see the IP they need to connect
to for accessing the web interface.

Closes https://github.com/sieren/Homepoint/issues/49
Addresses https://github.com/sieren/Homepoint/issues/38