### PR TITLE
Typo in md / mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please refer to the [documentation](https://docs.espressif.com/projects/esp-idf/
 On Linux:
 
 ```
-$ md ~/esp
+$ mkdir ~/esp
 $ cd ~/esp
 $ git clone -b v4.0 --recursive https://github.com/espressif/esp-idf.git
 $ cd esp-idf


### PR DESCRIPTION
Switching between Linux and Windows all the time doesn't help. Sorry this slipped through...