### PR TITLE
Make Sensor Types fully Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HomePoint supports two types of Scenes with a selection of devices each:
 | SCENE Types   | DEVICE Types                                                                             |
 | --------------| ----------------------------------------------------------------------------------------- |
 | Light, Switch | (none, all devices expected to be switches)                                               |
-| Sensor        | display one or two values at once with customizable icons                                 |
+| Sensor        | display one or two values at once with customizable icons (singleValue / combinedValues)  |
 
 **Grouped Sensors** support up to two devices (due to screen space).  
 **Lights & Switches** support an infinite number of devices in a group.
@@ -206,7 +206,7 @@ In order to set the correct timezone, copy & paste your [NTP TZ Setting](https:/
     "icon": "door",
     "devices": [{
       "name": "Temperature DHT Sensor",
-      "type": "oneValue",
+      "type": "singleValue",
       "jsondata": true,
       "firstIcon": "temperature_small",
       "firstKey": "temperature",

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HomePoint supports two types of Scenes with a selection of devices each:
 | SCENE Types   | DEVICE Types                                                                             |
 | --------------| ----------------------------------------------------------------------------------------- |
 | Light, Switch | (none, all devices expected to be switches)                                               |
-| Sensor        | temperature, humidity, voc                                                                |
+| Sensor        | display one or two values at once with customizable icons                                 |
 
 **Grouped Sensors** support up to two devices (due to screen space).  
 **Lights & Switches** support an infinite number of devices in a group.
@@ -182,6 +182,8 @@ In order to set the correct timezone, copy & paste your [NTP TZ Setting](https:/
 {
   "wifi": "MyWifiSSID",
   "password": "My Wifi Password",
+  "login": "admin",
+  "webpass": "admin",
   "mqttbroker": "mqtt://192.168.1.2",
   "mqttusername": "mqttusername",
   "mqttpasswd": "mymqttpassword",
@@ -204,9 +206,10 @@ In order to set the correct timezone, copy & paste your [NTP TZ Setting](https:/
     "icon": "door",
     "devices": [{
       "name": "Temperature DHT Sensor",
-      "type": "temperature",
+      "type": "oneValue",
       "jsondata": true,
-      "temperatureKey": "temperature",
+      "firstIcon": "temperature_small",
+      "firstKey": "temperature",
       "getTopic": "bedroom/esptemp"
     }]
   }]

--- a/data/config_example.json
+++ b/data/config_example.json
@@ -91,7 +91,7 @@
     "icon": "door",
     "devices": [{
       "name": "Living Room DHT",
-      "type": "twoValues",
+      "type": "combinedValues",
       "firstIcon": "temperature_small",
       "secondIcon": "humidity_small",
       "jsondata": true,
@@ -106,7 +106,7 @@
     "icon": "door",
     "devices": [{
       "name": "Bedroom DHT Temp",
-      "type": "oneValue",
+      "type": "singleValue",
       "jsondata": true,
       "firstIcon": "temperature_small",
       "firstKey": "temperature",
@@ -114,7 +114,7 @@
     },
     {
       "name": "Bedroom DHT Humidity",
-      "type": "oneValue",
+      "type": "singleValue",
       "jsondata": true,
       "firstIcon": "humidity_small",
       "firstKey": "humidity",
@@ -139,17 +139,5 @@
       "onValue": "true",
       "offValue": "false"
     }]
-  },
-  {
-    "name": "Air Quality",
-    "type": "Sensor",
-    "icon": "voc",
-    "devices": [{
-      "name": "Bedroom",
-      "type": "voc",
-      "jsondata": true,
-      "vocKey": "CO2",
-      "getTopic": "bedroom/co2"
-    }]
-  }]
+  }
 }

--- a/data/config_example.json
+++ b/data/config_example.json
@@ -91,10 +91,12 @@
     "icon": "door",
     "devices": [{
       "name": "Living Room DHT",
-      "type": "temperaturehumidity",
+      "type": "twoValues",
+      "firstIcon": "temperature_small",
+      "secondIcon": "humidity_small",
       "jsondata": true,
-      "temperatureKey": "temperature",
-      "humidityKey": "humidity",
+      "firstKey": "temperature",
+      "secondKey": "humidity",
       "getTopic": "livingroom/temphumidity"
     }]
   },
@@ -104,16 +106,18 @@
     "icon": "door",
     "devices": [{
       "name": "Bedroom DHT Temp",
-      "type": "temperature",
+      "type": "oneValue",
       "jsondata": true,
-      "temperatureKey": "temperature",
+      "firstIcon": "temperature_small",
+      "firstKey": "temperature",
       "getTopic": "bedroom/esptemp"
     },
     {
       "name": "Bedroom DHT Humidity",
-      "type": "humidity",
+      "type": "oneValue",
       "jsondata": true,
-      "humidityKey": "humidity",
+      "firstIcon": "humidity_small",
+      "firstKey": "humidity",
       "getTopic": "bedroom/esphumi"
     }]
   },

--- a/main/config/Icon.hpp
+++ b/main/config/Icon.hpp
@@ -8,8 +8,8 @@ namespace gfx
 namespace util
 {
 
-  static const std::string temperatureIcon = "temperature";
-  static const std::string humidityIcon = "humidity";
+  static const std::string firstValueIcon = "temperature";
+  static const std::string secondValueIcon = "humidity";
   static const std::string vocIcon = "voc";
 
   static const int SmallIconSize = 25; // 25x25px

--- a/main/config/Icon.hpp
+++ b/main/config/Icon.hpp
@@ -23,13 +23,6 @@ namespace util
     return std::make_pair(activeIcon, inActiveIcon);
   }
 
-  inline static const std::string GetSmallIcon(const std::string iconName)
-  {
-    const auto smallAppend = "/" + iconName + "_small.jpg";
-
-    return smallAppend;
-  }
-
   inline static const std::string GetIconFilePath(const std::string name)
   {
     const auto fullPath = "/" + name + ".jpg";

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -170,25 +170,24 @@ namespace fs
       if (sensorDevice.dataType == MQTTSensorDataType::JSON)
       {
         std::vector<ValueTuple> vals;
-        if (sensorDevice.sensorType == MQTTSensorType::MQTTTemperatureHumidity)
+        if (sensorDevice.sensorType == MQTTSensorType::MQTTTwoValues)
         {
-          ValueTuple temperatureTuple;
-          read(device, MQTTTemperatureKeyJSON.c_str(), [&](std::string temp) {
-            temperatureTuple = {MQTTTemperatureKeyJSON, temp, std::string("0")};
+          ValueTuple firstValueTuple;
+          read(device, MQTTFirstKey.c_str(), [&](std::string temp) {
+            firstValueTuple = {MQTTFirstKey, temp, std::string("0")};
           });
-          ValueTuple humidityTuple;
-          read(device, MQTTHumidityKeyJSON.c_str(), [&](std::string humi) {
-            humidityTuple = {MQTTHumidityKeyJSON, humi, std::string("0")};
+          ValueTuple secondValueTuple;
+          read(device, MQTTSecondKey.c_str(), [&](std::string humi) {
+            secondValueTuple = {MQTTSecondKey, humi, std::string("0")};
           });
-          vals.push_back(std::move(temperatureTuple));
-          vals.push_back(std::move(humidityTuple));
+          vals.push_back(std::move(firstValueTuple));
+          vals.push_back(std::move(secondValueTuple));
         }
         else
         {
-          const auto sensorType = MQTTSensorTypeJSONKey(sensorDevice.sensorType);
           ValueTuple mappedValues;
-          read(device, sensorType.c_str(), [&](std::string val) {
-            mappedValues = {sensorType, val, std::string("0")};
+          read(device, MQTTFirstKey.c_str(), [&](std::string val) {
+            mappedValues = {MQTTFirstKey, val, std::string("0")};
           });
           vals.push_back(std::move(mappedValues));
         }

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -195,6 +195,8 @@ namespace fs
       }
       read(device, "name", [&](std::string name) { sensorDevice.name = name; });
       read(device, "getTopic", [&](std::string topic) { sensorDevice.getTopic = topic; });
+      read(device, "firstIcon", [&](std::string icon) { sensorDevice.firstIconName = icon; });
+      read(device, "secondIcon", [&](std::optional<std::string> icon) { sensorDevice.secondIconName = icon; });
       return sensorDevice;
     };
 

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -170,7 +170,7 @@ namespace fs
       if (sensorDevice.dataType == MQTTSensorDataType::JSON)
       {
         std::vector<ValueTuple> vals;
-        if (sensorDevice.sensorType == MQTTSensorType::MQTTTwoValues)
+        if (sensorDevice.sensorType == MQTTSensorType::MQTTCombinedValues)
         {
           ValueTuple firstValueTuple;
           read(device, MQTTFirstKey.c_str(), [&](std::string temp) {

--- a/main/mqtt/MQTTSensorGroup.hpp
+++ b/main/mqtt/MQTTSensorGroup.hpp
@@ -4,6 +4,7 @@
 #include "MQTTSensorUtils.hpp"
 #include "MQTTSensorTypes.hpp"
 
+#include <optional>
 #include <vector>
 
 namespace mqtt
@@ -54,6 +55,8 @@ namespace mqtt
     int deviceId = 0;
     MQTTSensorType sensorType;
     MQTTSensorDataType dataType;
+    std::string firstIconName;
+    std::optional<std::string> secondIconName;
   };
 
   struct MQTTSensorGroup : public MQTTGroup

--- a/main/mqtt/MQTTSensorGroup.hpp
+++ b/main/mqtt/MQTTSensorGroup.hpp
@@ -16,29 +16,20 @@ namespace mqtt
     std::string value;
     std::vector<ValueTuple> mappedValues;
 
-    std::string getTemperature()
+    std::string getFirstValue()
     {
       if (dataType == MQTTSensorDataType::JSON)
       {
-        return util::FindValue(mappedValues, MQTTTemperatureKeyJSON);
+        return util::FindValue(mappedValues, MQTTFirstKey);
       }
       return value;
     }
 
-    std::string getHumidity()
+    std::string getSecondValue()
     {
       if (dataType == MQTTSensorDataType::JSON)
       {
-        return util::FindValue(mappedValues, MQTTHumidityKeyJSON);
-      }
-      return value;
-    }
-    
-    std::string getVOC()
-    {
-      if (dataType == MQTTSensorDataType::JSON)
-      {
-        return util::FindValue(mappedValues, MQTTVOCKeyJSON);
+        return util::FindValue(mappedValues, MQTTSecondKey);
       }
       return value;
     }

--- a/main/mqtt/MQTTSensorTypes.hpp
+++ b/main/mqtt/MQTTSensorTypes.hpp
@@ -6,8 +6,8 @@ namespace mqtt
   enum class MQTTSensorType
   {
     // comments are JSON type values
-    MQTTValue, // = single value
-    MQTTTwoValues, // = temperaturehumidityjson
+    MQTTSingleValue, // = single value
+    MQTTCombinedValues, // = two values in UI
     MQTTINVALID // Invalid Type
   };
 

--- a/main/mqtt/MQTTSensorTypes.hpp
+++ b/main/mqtt/MQTTSensorTypes.hpp
@@ -6,10 +6,8 @@ namespace mqtt
   enum class MQTTSensorType
   {
     // comments are JSON type values
-    MQTTTemperature, // = temperature
-    MQTTHumidity, // = humidity
-    MQTTTemperatureHumidity, // = temperaturehumidityjson
-    MQTTVOC, // = voc
+    MQTTValue, // = single value
+    MQTTTwoValues, // = temperaturehumidityjson
     MQTTINVALID // Invalid Type
   };
 
@@ -19,21 +17,8 @@ namespace mqtt
     JSON
   };
 
-  inline static const std::string MQTTSensorTypeJSONKey(MQTTSensorType sensorType)
-  {
-    const std::map<MQTTSensorType, const std::string> sensorTypes {
-      {MQTTSensorType::MQTTHumidity, "humidityKey"},
-      {MQTTSensorType::MQTTTemperature, "temperatureKey"},
-      {MQTTSensorType::MQTTTemperatureHumidity, "temperaturehumidity"},
-      {MQTTSensorType::MQTTVOC, "vocKey"}
-    };
-    auto it = sensorTypes.find(sensorType);
-    return it == sensorTypes.end() ? "Out of range" : it->second;
-  }
-
-  static const std::string MQTTHumidityKeyJSON = "humidityKey";
-  static const std::string MQTTTemperatureKeyJSON = "temperatureKey";
-  static const std::string MQTTVOCKeyJSON = "vocKey";
+  static const std::string MQTTFirstKey = "firstKey";
+  static const std::string MQTTSecondKey = "secondKey";
 
   using DataTypeKey = std::string;
   using JSONValueKey = std::string;

--- a/main/mqtt/MQTTSensorUtils.hpp
+++ b/main/mqtt/MQTTSensorUtils.hpp
@@ -25,8 +25,8 @@ namespace util
   inline static auto GetSensorType(const std::string typeName) -> MQTTSensorType
   {
     // map JSON Keys to Enum
-    if (typeName == "oneValue") { return MQTTSensorType::MQTTValue; }
-    if (typeName == "twoValues") { return MQTTSensorType::MQTTTwoValues; }
+    if (typeName == "singleValue") { return MQTTSensorType::MQTTSingleValue; }
+    if (typeName == "combinedValues") { return MQTTSensorType::MQTTCombinedValues; }
     return MQTTSensorType::MQTTINVALID;
   }
 

--- a/main/mqtt/MQTTSensorUtils.hpp
+++ b/main/mqtt/MQTTSensorUtils.hpp
@@ -25,10 +25,8 @@ namespace util
   inline static auto GetSensorType(const std::string typeName) -> MQTTSensorType
   {
     // map JSON Keys to Enum
-    if (typeName == "temperature") { return MQTTSensorType::MQTTTemperature; }
-    if (typeName == "humidity") { return MQTTSensorType::MQTTHumidity; }
-    if (typeName == "temperaturehumidity") { return MQTTSensorType::MQTTTemperatureHumidity; }
-    if (typeName == "voc") { return MQTTSensorType::MQTTVOC; }
+    if (typeName == "oneValue") { return MQTTSensorType::MQTTValue; }
+    if (typeName == "twoValues") { return MQTTSensorType::MQTTTwoValues; }
     return MQTTSensorType::MQTTINVALID;
   }
 

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -98,38 +98,25 @@ namespace util
       {
         switch(sensor.second.sensorType)
         {
-          case MQTTSensorType::MQTTTemperatureHumidity:
+          case MQTTSensorType::MQTTTwoValues:
           {
-            const auto temperature = sensor.second.getTemperature();
-            const auto humidity = sensor.second.getHumidity();
-            const auto humidityIcon = util::GetSmallIcon(util::humidityIcon);
-            const auto temperatureIcon = util::GetSmallIcon(util::temperatureIcon);
-            button->setImageWithValue({temperatureIcon, temperature});
-            button->setImageWithValue({humidityIcon, humidity});
-            break;
-          }
-          case MQTTSensorType::MQTTTemperature:
-          {
-            const auto temperature = sensor.second.getTemperature();
-            const auto temperatureIcon = util::GetSmallIcon(util::temperatureIcon);
-            button->setImageWithValue({temperatureIcon, temperature});
-            break;
-          }
-          case MQTTSensorType::MQTTHumidity:
-          {
-            const auto humidityIcon = util::GetSmallIcon(util::humidityIcon);
-            const auto humidity = sensor.second.getHumidity();
-            button->setImageWithValue({humidityIcon, humidity});
+            const auto firstValue = sensor.second.getFirstValue();
+            const auto secondValue = sensor.second.getSecondValue();
+            const auto secondValueIcon = util::GetSmallIcon(util::secondValueIcon);
+            const auto firstValueIcon = util::GetSmallIcon(util::firstValueIcon);
+            button->setImageWithValue({firstValueIcon, firstValue});
+            button->setImageWithValue({secondValueIcon, secondValue});
             break;
           }
 
-          case MQTTSensorType::MQTTVOC:
+          case MQTTSensorType::MQTTValue:
           {
-            const auto vocIcon = util::GetSmallIcon(util::vocIcon);
-            const auto vocVal = sensor.second.getVOC();
-            button->setImageWithValue({vocIcon, vocVal});
+            const auto firstValue = sensor.second.getFirstValue();
+            const auto firstValueIcon = util::GetSmallIcon(util::firstValueIcon);
+            button->setImageWithValue({firstValueIcon, firstValue});
             break;
           }
+
           default:
             break;
         }

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -102,8 +102,10 @@ namespace util
           {
             const auto firstValue = sensor.second.getFirstValue();
             const auto secondValue = sensor.second.getSecondValue();
-            const auto secondValueIcon = util::GetSmallIcon(util::secondValueIcon);
-            const auto firstValueIcon = util::GetSmallIcon(util::firstValueIcon);
+
+            const auto firstValueIcon = util::GetIconFilePath(sensor.second.firstIconName);
+            const auto secondValueIcon = sensor.second.secondIconName.has_value() ?
+              util::GetIconFilePath(*sensor.second.secondIconName) : firstValueIcon; // fallback
             button->setImageWithValue({firstValueIcon, firstValue});
             button->setImageWithValue({secondValueIcon, secondValue});
             break;
@@ -112,7 +114,7 @@ namespace util
           case MQTTSensorType::MQTTValue:
           {
             const auto firstValue = sensor.second.getFirstValue();
-            const auto firstValueIcon = util::GetSmallIcon(util::firstValueIcon);
+            const auto firstValueIcon = util::GetIconFilePath(sensor.second.firstIconName);
             button->setImageWithValue({firstValueIcon, firstValue});
             break;
           }

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -98,7 +98,7 @@ namespace util
       {
         switch(sensor.second.sensorType)
         {
-          case MQTTSensorType::MQTTTwoValues:
+          case MQTTSensorType::MQTTCombinedValues:
           {
             const auto firstValue = sensor.second.getFirstValue();
             const auto secondValue = sensor.second.getSecondValue();
@@ -111,7 +111,7 @@ namespace util
             break;
           }
 
-          case MQTTSensorType::MQTTValue:
+          case MQTTSensorType::MQTTSingleValue:
           {
             const auto firstValue = sensor.second.getFirstValue();
             const auto firstValueIcon = util::GetIconFilePath(sensor.second.firstIconName);


### PR DESCRIPTION
Delete hard-coded and predefined Sensor-Types and Icons for Temperature, Humidity and VOC and instead introduce two different types:

- oneValue
- twoValues

One Value can either be Raw or JSON, whereas twoValues has to be in JSON Format.
Behaviour is the same, except users now have to provide a JPG for the icon through the JSON:
**oneValue** (single value)
```
    "devices": [{
      "name": "Temperature DHT Sensor",
      "type": "oneValue",
      "jsondata": true,
      "firstIcon": "temperature_small",
      "firstKey": "temperature",
      "getTopic": "bedroom/esptemp"
    }]
```

**twoValue** (twin values)
```
    "devices": [{
      "name": "Living Room DHT",
      "type": "twoValues",
      "firstIcon": "temperature_small",
      "secondIcon": "humidity_small",
      "jsondata": true,
      "firstKey": "temperature",
      "secondKey": "humidity",
      "getTopic": "livingroom/temphumidity"
    }]
```


ping @jholthusen ... do you have any suggestions for better names? I don't find `oneValue` \ `twoValues` that easy to understand...
