### PR TITLE
NTP: Don't check for empty string for shared ptr

### DIFF
--- a/main/AppContext.cpp
+++ b/main/AppContext.cpp
@@ -88,7 +88,7 @@ namespace ctx
     {
       if (mModel.mTimeZone != "")
       {
-        mNTPSync = mModel.mTimeZone != "" ? std::make_shared<ntp::NTPSync>(mModel.mTimeZone) : nullptr;
+        mNTPSync = std::make_shared<ntp::NTPSync>(mModel.mTimeZone);
         mNTPSync->syncTime();
       }
       if (mpMQTTConnection && !mModel.mMQTTServerConfig.addr.empty())


### PR DESCRIPTION
This check is void because we already check in the if-statement
surrounding the NTP server instantiation.

Closes https://github.com/sieren/Homepoint/issues/61