### PR TITLE
Add HW Configuration Options to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ WiFi and MQTT credentials are to be defined on the top level.
 
 In order to set the correct timezone, copy & paste your [NTP TZ Setting](https://remotemonitoringsystems.ca/time-zone-abbreviations.php) to the `timezone` key.
 
+<a name="hardware"></a>
+## Hardware (optional)
+
+Some of the IL9341 Display units seem to differ in e.g. how the touch-screen coordinates corresponds to the display
+or how the LED backlight is controlled. Therefore we offer some options to override the defaults in the configuration file.
+
+| Key   | Value                                                                                             |
+| --------------| ----------------------------------------------------------------------------------------- |
+| "ledPinPullup" | `true` or `false` - control backlight power which can be pull-up/down depending on unit  |
+| "screenRotationAngle" | The rotation parameter can be 0, 1, 2 or 3 - incrementing in 90deg angles         |
+| "screenSaverMinutes" | Minutes (int) until display is switched off (default 10)                          |
+
 
 <a name="examples"></a>
 

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -34,7 +34,7 @@ namespace gfx
     mNavigation(mTft.getDriverRef()),
     mpAppContext(ctx),
     mpStatusBar(new UIStatusBarWidget(&mTft, Frame{{0,0,0}, {size.width, kStatusBarHeight}}, 999)),
-    mScreenSaver(&mTft)
+    mScreenSaver(&mTft, ctx)
   {
   };
 
@@ -87,7 +87,7 @@ namespace gfx
   void AppScreen<ScreenDriver, NavigationDriver>::setupScreen()
   {
     mTft.begin(320000000);
-    mTft.setRotation(Rotation);
+    mTft.setRotation(mpAppContext->getModel().mHardwareConfig.mScreenRotationAngle);
     mpStatusBar->setBackgroundColor(Color::BlackColor());
     mpStatusBar->setTextColor(Color::WhiteColor());
 

--- a/main/config/Config.h
+++ b/main/config/Config.h
@@ -5,6 +5,8 @@
 #include <tft/TFTESPIDriver.hpp>
 #include <ui/PROGMEMIconDrawer.hpp>
 
+#include <optional>
+
 using ScreenDriver = gfx::driver::TFTESPI; // gfx::driver::MiniGrafxDriver;
 using ImageWriter = gfx::util::PROGMEMIconDrawer<ScreenDriver>; // gfx::util::SPIFFSIconDrawer for SPIFFS only
 
@@ -29,58 +31,45 @@ static const unsigned long MinsBeforeScreenSleep = 10; // Minutes before putting
   #define BUTTON_A_PIN 39
   #define BUTTON_B_PIN 38
   #define BUTTON_C_PIN 37
-  static const int Rotation = 1; // Set rotation angle
+  #define LED_PIN_INVERTED true // M5Stack uses Pull Up, therefore inverted.
+  #define SCREEN_ROTATION_ANGLE 1
   static const bool ButtonsArePullUp = true;
   using NavigationDriver = gfx::ButtonDriver; 
-  // M5Stack uses Pull Up, therefore inverted.
-  auto ScreenOnOffSwitch = [](ScreenDriver* driver, bool on)
+  auto ScreenOnOffSwitch = [](ScreenDriver* driver, bool on, bool inverted = true)
   {
-    const auto backLightPower = on ? HIGH : LOW;
+    const auto highVal = inverted ? HIGH : LOW;
+    const auto lowVal = !inverted ? HIGH : LOW;
+    const auto backLightPower = on ? highVal : lowVal;
     const auto screenPower = on ? ILI9341_DISPON : ILI9341_DISPOFF;
     digitalWrite(TFT_LED, backLightPower);
     driver->writeCommand(screenPower);
   };
 
-// Please define PINs in libraries/TFT_ESPI/User_Setup.h
-// #define M5Stack
-// #define TFT_MISO 19
-// #define TFT_MOSI 23
-// #define TFT_SCLK 18
-// #define TFT_CS   14  // Chip select control pin
-// #define TFT_DC   27  // Data Command control pin
-// #define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
-// #define TFT_BL   32  // LED back-light (required for M5Stack)
-// #define TFT_LED   32
-
 #else // Touch Screen
   #define BUTTON_A_PIN 0 // unused
   #define BUTTON_B_PIN 0 // unused
   #define BUTTON_C_PIN 0 // unused
-  static const int Rotation = 3; // Set rotation angle
+  #define LED_PIN_INVERTED false
+  #define SCREEN_ROTATION_ANGLE 3
   using NavigationDriver = gfx::TouchDriver;
   static const bool ButtonsArePullUp = false;
-  auto ScreenOnOffSwitch = [](ScreenDriver* driver, bool on)
+  auto ScreenOnOffSwitch = [](ScreenDriver* driver, bool on, bool inverted = false)
   {
-    const auto state = on ? LOW : HIGH;
+    const auto highVal = inverted ? HIGH : LOW;
+    const auto lowVal = !inverted ? HIGH : LOW;
+    const auto backLightPower = on ? highVal : lowVal;
     const auto screenPower = on ? ILI9341_DISPON : ILI9341_DISPOFF;
-    digitalWrite(TFT_LED, state);
+    digitalWrite(TFT_LED, backLightPower);
     driver->writeCommand(screenPower);
   };
 #endif                          
 
-// Please define PINs in libraries/TFT_ESPI/User_Setup.h
-// The following are examples for ArduiTouch (ILI9341 Display)
-// #define TFT_CS   5
-// #define TFT_DC   4
-// #define TFT_MOSI 23
-// #define TFT_CLK  18
-// #define TFT_RST  22
-// #define TFT_MISO 19
-// #define TFT_LED  15  
-
-// #define HAVE_TOUCHPAD
-// #define TOUCH_CS 14
-// #define TOUCH_IRQ 2
-/*_______End of definitions______*/
-
-// M5Stack Definitions
+namespace config
+{
+  struct HardwareConfig
+  {
+    bool mIsLEDPinInverted = LED_PIN_INVERTED;
+    int mScreensaverMins = 10;
+    int mScreenRotationAngle = SCREEN_ROTATION_ANGLE;
+  };
+}

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -278,5 +278,29 @@ namespace fs
       return vecScenes;
     };
 
+    const config::HardwareConfig ConfigReader::getHardwareConfig(const rapidjson::Value::ConstObject document)
+    {
+      using namespace rapidjson;
+      config::HardwareConfig hwConfig;
+      read(document, "ledPinPullup", [&] (bool isPullUp)
+        {
+          hwConfig.mIsLEDPinInverted = isPullUp;
+        }
+      );
+
+      read(document, "screenSaverMinutes", [&] (int mins)
+          {
+            hwConfig.mScreensaverMins = mins;
+          }
+        );
+
+      read(document, "screenRotationAngle", [&] (int angle)
+          {
+            hwConfig.mScreenRotationAngle = angle;
+          }
+        );
+
+      return hwConfig;
+    }
   
 } // namespace fs

--- a/main/fs/ConfigReader.hpp
+++ b/main/fs/ConfigReader.hpp
@@ -30,7 +30,7 @@ class ConfigReader
     const std::string getTimeZone(const rapidjson::Value::ConstObject document);
     const mqtt::MQTTConfig getMQTTConfig(const rapidjson::Value::ConstObject document);
     const std::vector<MQTTVariants> getMQTTGroups(const rapidjson::Value::ConstObject document);
-  //  std::vector<MQTTVariants> getScenes(json::JsonArray scenes);
+    const config::HardwareConfig getHardwareConfig(const rapidjson::Value::ConstObject document);
 
 };
 } // namespace fs

--- a/main/model/Model.hpp
+++ b/main/model/Model.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <config/Config.h>
 #include <mqtt/MQTTConnection.h>
 #include <mqtt/MQTTGroup.hpp>
 #include <mqtt/MQTTSensorGroup.hpp>
@@ -18,6 +19,7 @@ struct Model
 {
   WifiCredentials mWifiCredentials;
   WebCredentials mWebCredentials;
+  config::HardwareConfig mHardwareConfig;
   std::string mTimeZone;
   mqtt::MQTTConfig mMQTTServerConfig;
   std::vector<MQTTVariants> mMQTTGroups;

--- a/main/tft/ScreenSaver.hpp
+++ b/main/tft/ScreenSaver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AppContext.h>
 #include <config/Config.h>
 #include <touch/TouchTypes.hpp>
 
@@ -12,8 +13,9 @@ namespace gfx
   struct ScreenSaver
   {
     public:
-      ScreenSaver(ScreenDriver* driver) :
-        mDriver(driver)
+      ScreenSaver(ScreenDriver* driver, std::shared_ptr<ctx::AppContext> ctx) :
+        mpDriver(driver),
+        mpCtx(ctx)
       {
         mLastTouch = std::chrono::system_clock::now();
         pinMode(TFT_LED, OUTPUT);
@@ -23,7 +25,8 @@ namespace gfx
       void operator()()
       {
         auto now = std::chrono::system_clock::now();
-        if (std::chrono::duration_cast<std::chrono::minutes>(now - mLastTouch).count() > MinsBeforeScreenSleep)
+        const auto timeOut = mpCtx->getModel().mHardwareConfig.mScreensaverMins;
+        if (std::chrono::duration_cast<std::chrono::minutes>(now - mLastTouch).count() > timeOut)
         {
           switchScreen(false);
         }
@@ -61,13 +64,14 @@ namespace gfx
         {
           return;
         }
-        ScreenOnOffSwitch(mDriver, on);
+        ScreenOnOffSwitch(mpDriver, on, mpCtx->getModel().mHardwareConfig.mIsLEDPinInverted);
         mCurrentState = on;
       }
 
       std::chrono::system_clock::time_point mLastTouch;
       bool mCurrentState = true;
-      ScreenDriver* mDriver;
+      ScreenDriver* mpDriver;
+      std::shared_ptr<ctx::AppContext> mpCtx;
 
   };
 } // namespace gfx


### PR DESCRIPTION
Add options to configure some of the Display through the `config.json` file.

## Hardware (optional)
 | Key   | Value                                                                                             |
| --------------| ----------------------------------------------------------------------------------------- |
| "ledPinPullup" | `true` or `false` - control backlight power which can be pull-up/down depending on unit  |
| "screenRotationAngle" | The rotation parameter can be 0, 1, 2 or 3 - incrementing in 90deg angles         |
| "screenSaverMinutes" | Minutes (int) until displaty is switched off (default 10)                          |



Addresses / Closes https://github.com/sieren/Homepoint/issues/72 https://github.com/sieren/Homepoint/issues/73