### PR TITLE
Fix missing Hardware Configuration

### DIFF
--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -131,7 +131,7 @@ namespace gfx
     registerWifiCallback();
     mpAppContext->registerStateCallback(std::bind(&AppScreen::appContextChanged, this, _1));
     mpAppContext->getMQTTConnection()->registerConnectionStatusCallback(std::bind(&UIStatusBarWidget::mqttConnectionChanged, mpStatusBar.get(), _1));
-
+    mTft.setRotation(mpAppContext->getModel().mHardwareConfig.mScreenRotationAngle);
     mpSubViews.clear();
     presentMenu();
   }

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -35,6 +35,7 @@ namespace fs
       model.mTimeZone = getTimeZone(rootObj);
       model.mMQTTServerConfig = getMQTTConfig(rootObj);
       model.mMQTTGroups = getMQTTGroups(rootObj);
+      model.mHardwareConfig = getHardwareConfig(rootObj);
       return model;
     }
 


### PR DESCRIPTION
Reading out the HW configuration was missing as well as
setting the screen rotation angle at the right point.

Closes https://github.com/sieren/Homepoint/issues/84