### PR TITLE
Add support for Hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ MQTT Topics are case-sensitive as per MQTT specification.
 {
   "wifi": "MyWifiSSID",
   "password": "My Wifi Password",
+  "hostname": "optionalhostname",
   "login": "admin",
   "webpass": "admin",
   "mqttbroker": "mqtt://192.168.1.2",

--- a/main/AppContext.cpp
+++ b/main/AppContext.cpp
@@ -72,7 +72,8 @@ namespace ctx
 
   void AppContext::connectWireless()
   {
-    getWifiContext().connect(std::get<0>(mModel.mWifiCredentials), std::get<1>(mModel.mWifiCredentials));
+    auto& wifi = mModel.mWifiCredentials;
+    getWifiContext().connect(wifi.mSSID, wifi.mPassword, wifi.mHostname);
     using namespace std::placeholders;
     getWifiContext().registerCallback(std::bind(&AppContext::connectionStateChanged, this, _1));
   }

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -106,7 +106,7 @@ namespace fs
       return std::make_tuple(ssid, password);
     }
 
-    const WifiCredentials ConfigReader::getWebCredentials(const rapidjson::Value::ConstObject document)
+    const WebCredentials ConfigReader::getWebCredentials(const rapidjson::Value::ConstObject document)
     {
       using namespace rapidjson;
       std::string web;

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -69,11 +69,11 @@ namespace fs
 
       document.SetObject();
       ElemType ssidName(kStringType);
-      ssidName.SetString(std::get<0>(credentials).c_str(), std::get<0>(credentials).length(), document.GetAllocator());
+      ssidName.SetString(credentials.mSSID.c_str(), credentials.mSSID.length(), document.GetAllocator());
       document.AddMember("wifi", ssidName.Move(), document.GetAllocator());
 
       ElemType wifiPassword(kStringType);
-      wifiPassword.SetString(std::get<1>(credentials).c_str(), std::get<1>(credentials).length(), document.GetAllocator());
+      wifiPassword.SetString(credentials.mPassword.c_str(), credentials.mPassword.length(), document.GetAllocator());
       document.AddMember("password", wifiPassword.Move(), document.GetAllocator());
 
       ElemType webLogin(kStringType);
@@ -101,9 +101,17 @@ namespace fs
       using namespace rapidjson;
       std::string ssid;
       std::string password;
-      read(document, "wifi", [&ssid] (std::string wifi) { ssid = wifi; });
-      read(document, "password", [&password] (std::string passwd) { password = passwd; });
-      return std::make_tuple(ssid, password);
+      WifiCredentials wifiCredentials;
+      read(document, "wifi", [&wifiCredentials] (std::string wifi) {
+        wifiCredentials.mSSID = wifi;
+      });
+      read(document, "password", [&wifiCredentials] (std::string passwd) {
+        wifiCredentials.mPassword = passwd;
+      });
+      read(document, "hostname", [&wifiCredentials] (std::optional<std::string> hostname) {
+        wifiCredentials.mHostname = hostname;
+      });
+      return wifiCredentials;
     }
 
     const WebCredentials ConfigReader::getWebCredentials(const rapidjson::Value::ConstObject document)

--- a/main/fs/ConfigReader.hpp
+++ b/main/fs/ConfigReader.hpp
@@ -26,7 +26,7 @@ class ConfigReader
 
   private:
     const WifiCredentials getWifiCredentials(const rapidjson::Value::ConstObject document);
-    const WifiCredentials getWebCredentials(const rapidjson::Value::ConstObject document);
+    const WebCredentials getWebCredentials(const rapidjson::Value::ConstObject document);
     const std::string getTimeZone(const rapidjson::Value::ConstObject document);
     const mqtt::MQTTConfig getMQTTConfig(const rapidjson::Value::ConstObject document);
     const std::vector<MQTTVariants> getMQTTGroups(const rapidjson::Value::ConstObject document);

--- a/main/ui/UIStatusBarWidget.cpp
+++ b/main/ui/UIStatusBarWidget.cpp
@@ -33,6 +33,10 @@ namespace gfx
         mIpAddressLabel = "DISCONNECTED";
         mWifiImage = "wifi_off";
         break;
+      case WifiAssociationState::READY:
+        mIpAddressLabel = "READY";
+        mWifiImage = "wifi_off";
+        break;
     }
     mNeedsRedraw = true;
   }

--- a/main/wifi/CaptiveServer.cpp
+++ b/main/wifi/CaptiveServer.cpp
@@ -77,7 +77,7 @@ namespace wifi
     }
 
     ESP_LOGI(TAG, "Updating Configuration");
-    const auto credentials = std::make_tuple(ssid, ssidPassword);
+    const auto credentials = WifiCredentials{ssid, ssidPassword, std::nullopt};
     mpAppContext->setFirstLaunch(credentials, webLogin, webPassword);
     request->redirect("/index.html");
   }

--- a/main/wifi/WifiContext.h
+++ b/main/wifi/WifiContext.h
@@ -3,13 +3,16 @@
 #include <util/dispatcher.hpp>
 #include "esp_event.h"
 
+#include <optional>
+
 namespace ctx
 {
   enum class WifiAssociationState: int
   {
     CONNECTED = 0,
     DISCONNECTED = 1,
-    CONNECTING = 2
+    CONNECTING = 2,
+    READY = 3
   };
 
   struct WifiConnectionState
@@ -24,7 +27,8 @@ namespace ctx
   {
     public:
       WifiContext();
-      void connect(const std::string ssid, const std::string passwd);
+      void connect(const std::string ssid, const std::string passwd,
+        const std::optional<std::string> hostname);
       void disconnect();
       void registerCallback(WifiConnectionStateCB callback);
 
@@ -38,6 +42,7 @@ namespace ctx
       Dispatcher<WifiConnectionState> mWifiStateNotifier;
       std::string mSSID;
       std::string mPassword;
+      std::optional<std::string> mHostname;
       wificallback_t mWifiCallback; // Need to store so doesnt go out of scope in C land
   };
 } // namespace ctx


### PR DESCRIPTION
Add support to specify the devices hostname through the `hostname` key in config.json.
Closes https://github.com/sieren/Homepoint/issues/95