### PR TITLE
[Configuration] Add Options to invert the touch screen axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,15 @@ In order to set the correct timezone, copy & paste your [NTP TZ Setting](https:/
 Some of the IL9341 Display units seem to differ in e.g. how the touch-screen coordinates correspond to the display
 or how the LED backlight is controlled. Therefore we offer some options to override the defaults in the configuration file.
 
-| Key   | Value                                                                                             |
+| Key   | Type | Value                                                                                             |
 | --------------| ----------------------------------------------------------------------------------------- |
-| "ledPinPullup" | `true` or `false` - control backlight power which can be pull-up/down depending on unit  |
-| "screenRotationAngle" | The rotation parameter can be 0, 1, 2 or 3 - incrementing in 90deg angles         |
-| "screenSaverMinutes" | Minutes (int) until display is switched off (default 10)                          |
+| "ledPinPullup" | Boolean | `true` or `false` - control backlight power which can be pull-up/down depending on unit  |
+| "screenRotationAngle" | Int | The rotation parameter can be 0, 1, 2 or 3 - incrementing in 90deg angles         |
+| "screenSaverMinutes" | Int | Minutes until display is switched off (default 10)                          |
+| "screenSaverMinutes" | Int | Minutes until display is switched off (default 10)                          |
+| "screenSaverMinutes" | Int | Minutes until display is switched off (default 10)                          |
+| "touchXAxisInverted" | Bool | default: `false`, invert the X Axis of the touch screen in case it is misaligned |
+| "touchYAxisInverted" | Bool | default: `true`, invert the Y Axis of the touch screen in case it is misaligned |
 
 
 <a name="examples"></a>

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -31,7 +31,7 @@ namespace gfx
     mViewPortSize({mWindowSize.width, mWindowSize.height - kStatusBarHeight}),
     menuFrame({{0, kStatusBarHeight, 0}, mViewPortSize}),
     mTft(size.width, size.height),
-    mNavigation(mTft.getDriverRef()),
+    mNavigation(mTft.getDriverRef(), ctx->getModel().mHardwareConfig),
     mpAppContext(ctx),
     mpStatusBar(new UIStatusBarWidget(&mTft, Frame{{0,0,0}, {size.width, kStatusBarHeight}}, 999)),
     mScreenSaver(&mTft, ctx)

--- a/main/config/Config.h
+++ b/main/config/Config.h
@@ -17,6 +17,9 @@ static const unsigned long MSBeforeInvalid = 1500; // 2s before invalidate press
 static const unsigned long StatusBarUpdateInterval = 4; // update status bar every 10s to keep time up to date
 static const unsigned long MinsBeforeScreenSleep = 10; // Minutes before putting Screen to sleep
 
+static const int ScreenWidth = 320;
+static const int ScreenHeight = 240;
+
 //    _____  _            _______ ______ ____  _____  __  __ 
 //   |  __ \| |        /\|__   __|  ____/ __ \|  __ \|  \/  |
 //   | |__) | |       /  \  | |  | |__ | |  | | |__) | \  / |
@@ -71,5 +74,7 @@ namespace config
     bool mIsLEDPinInverted = LED_PIN_INVERTED;
     int mScreensaverMins = 10;
     int mScreenRotationAngle = SCREEN_ROTATION_ANGLE;
+    bool mIsTouchXAxisInverted = false;
+    bool mIsTouchYAxisInverted = true;
   };
 }

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -309,6 +309,18 @@ namespace fs
           }
         );
 
+      read(document, "touchXAxisInverted", [&] (bool touchXAxisInverted)
+        {
+          hwConfig.mIsTouchXAxisInverted = touchXAxisInverted;
+        }
+      );
+
+      read(document, "touchYAxisInverted", [&] (bool touchYAxisInverted)
+        {
+          hwConfig.mIsTouchYAxisInverted = touchYAxisInverted;
+        }
+      );
+
       return hwConfig;
     }
   

--- a/main/touch/TouchDriver.cpp
+++ b/main/touch/TouchDriver.cpp
@@ -1,13 +1,16 @@
 
 #include "TouchDriver.h"
+#include <config/Config.h>
 #include <tft/ScreenSaver.hpp>
 
 namespace gfx
 {
-  TouchDriver::TouchDriver(TFT_eSPI* tftDriver) :
+  TouchDriver::TouchDriver(TFT_eSPI* tftDriver, config::HardwareConfig& hwConfig) :
     mTouch(tftDriver)
   {
     mCurrentEvent = {{0,0,0}, TouchState::NoTouch, xTaskGetTickCount()};
+    mXAxisInversionAmount = hwConfig.mIsTouchXAxisInverted ? ScreenWidth : 0;
+    mYAxisInversionAmount = hwConfig.mIsTouchXAxisInverted ? ScreenHeight : 0;
   };
 
   auto TouchDriver::touchPoint() -> std::optional<TouchEvent>
@@ -36,7 +39,8 @@ namespace gfx
         default:
           break;
       }
-      y = std::abs(240 - y); // NEED TO INVERT FOR SOME REASON
+      y = std::abs(mYAxisInversionAmount - y);
+      x = std::abs(mXAxisInversionAmount - x);
       newEvent.position = {x, y, 0};
       newEvent.state = newState;
       mCurrentEvent = newEvent;

--- a/main/touch/TouchDriver.h
+++ b/main/touch/TouchDriver.h
@@ -6,13 +6,14 @@
 #include <optional>
 
 class TFT_eSPI;
+namespace config { struct HardwareConfig; }
 
 namespace gfx
 {
   class TouchDriver
   {
     public:
-      TouchDriver(TFT_eSPI* tftDriver);
+      TouchDriver(TFT_eSPI* tftDriver, config::HardwareConfig& hwConfig);
       void begin();
       void setRotation(int rotation);
 
@@ -23,5 +24,8 @@ namespace gfx
       unsigned long mLastTouchEventTime;
       TFT_eSPI* mTouch;
       TouchEvent mCurrentEvent;
+      int mXAxisInversionAmount;
+      int mYAxisInversionAmount;
+
   };
 } // namespace gfx


### PR DESCRIPTION
Add configurable options to invert the coordinates on the touch
layer, since some IL9341 units have inversed coordinates.

Addresses https://github.com/sieren/Homepoint/issues/101