### PR TITLE
Add Option to Invert Colorspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ or how the LED backlight is controlled. Therefore we offer some options to overr
 | "screenSaverMinutes" | Int | Minutes until display is switched off (default 10)                          |
 | "touchXAxisInverted" | Bool | default: `false`, invert the X Axis of the touch screen in case it is misaligned |
 | "touchYAxisInverted" | Bool | default: `true`, invert the Y Axis of the touch screen in case it is misaligned |
+| "displayColorInverted" | Bool | default: `false`, invert the colorspace (ie. for ILI9342C Displays) |
 
 
 <a name="examples"></a>

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -132,6 +132,7 @@ namespace gfx
     mpAppContext->registerStateCallback(std::bind(&AppScreen::appContextChanged, this, _1));
     mpAppContext->getMQTTConnection()->registerConnectionStatusCallback(std::bind(&UIStatusBarWidget::mqttConnectionChanged, mpStatusBar.get(), _1));
     mTft.setRotation(mpAppContext->getModel().mHardwareConfig.mScreenRotationAngle);
+    mTft.setDisplayInverted(mpAppContext->getModel().mHardwareConfig.mIsDisplayColorInverted);
     mNavigation.updateHardwareConfig(mpAppContext->getModel().mHardwareConfig);
     mpSubViews.clear();
     presentMenu();

--- a/main/config/Config.h
+++ b/main/config/Config.h
@@ -76,5 +76,6 @@ namespace config
     int mScreenRotationAngle = SCREEN_ROTATION_ANGLE;
     bool mIsTouchXAxisInverted = false;
     bool mIsTouchYAxisInverted = true;
+    bool mIsDisplayColorInverted = false;
   };
 }

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -321,6 +321,12 @@ namespace fs
         }
       );
 
+      read(document, "displayColorInverted", [&](bool displayColorInverted)
+        {
+          hwConfig.mIsDisplayColorInverted = displayColorInverted;
+        }
+      );
+
       return hwConfig;
     }
   

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -297,25 +297,25 @@ namespace fs
         }
       );
 
-      read(document, "screenSaverMinutes", [&] (int mins)
+      read(document, "screenSaverMinutes", [&](int mins)
           {
             hwConfig.mScreensaverMins = mins;
           }
         );
 
-      read(document, "screenRotationAngle", [&] (int angle)
+      read(document, "screenRotationAngle", [&](int angle)
           {
             hwConfig.mScreenRotationAngle = angle;
           }
         );
 
-      read(document, "touchXAxisInverted", [&] (bool touchXAxisInverted)
+      read(document, "touchXAxisInverted", [&](bool touchXAxisInverted)
         {
           hwConfig.mIsTouchXAxisInverted = touchXAxisInverted;
         }
       );
 
-      read(document, "touchYAxisInverted", [&] (bool touchYAxisInverted)
+      read(document, "touchYAxisInverted", [&](bool touchYAxisInverted)
         {
           hwConfig.mIsTouchYAxisInverted = touchYAxisInverted;
         }

--- a/main/tft/TFTESPIDriver.hpp
+++ b/main/tft/TFTESPIDriver.hpp
@@ -52,6 +52,11 @@ namespace driver
         mDriver.setRotation(rot);
       }
 
+      void setDisplayInverted(bool inverted)
+      {
+        mDriver.invertDisplay(inverted);
+      }
+
       void drawRect(Frame frame, Color color)
       {
         mSprite.drawRect(frame.position.x, frame.position.y, frame.size.width, frame.size.height, color.getColorInt());


### PR DESCRIPTION
Some newer displays like the ILI9342C rely on the colorspace being inverted.
This PR introduces "displayColorInverted" to the configuration file
to control inversion of the colorspace.

Addresses https://github.com/sieren/Homepoint/issues/112