### PR TITLE
Sensors: Display integers without fractions

### DIFF
--- a/main/mqtt/MQTTSensorUtils.hpp
+++ b/main/mqtt/MQTTSensorUtils.hpp
@@ -143,8 +143,9 @@ namespace util
       return foundValue.GetBool() ? "true" : "false";
     }
 
+    auto precision = (fmod(retVal, 1.0) == 0.0) ? 0 : 1;
     std::stringstream stream;
-    stream << std::fixed << std::setprecision(1) << retVal;
+    stream << std::fixed << std::setprecision(precision) << retVal;
     std::string s = stream.str();
 
     return s;


### PR DESCRIPTION
If a number is an integer, ignore the decimal point.

Closes https://github.com/sieren/Homepoint/issues/138