### PR TITLE
Add per-device Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,21 @@ MQTT Topics are case-sensitive as per MQTT specification.
     "type": "Light",
     "icon": "livingroom",
     "devices": [{
-      "name": "Side Light",
+      "name": "Some Light",
       "setTopic": "lights/hue/00:17:88:01:02:3c:2a:6d-0b/set/on",
       "getTopic": "hue/status/lights/Hue color lamp 1",
       "onValue": "true",
       "offValue": "false"
-    }]
+    },
+    {
+      "name": "Door Light",
+      "setTopic": "lights/hue/00:17:88:01:02:3c:2a:6d-0b/set/on",
+      "getTopic": "hue/status/lights/Hue color lamp 1",
+      "onValue": "true",
+      "offValue": "false",
+      "icon": "door"
+    },
+    ]
   },
   {
     "name": "Bedroom",

--- a/data/config_example.json
+++ b/data/config_example.json
@@ -16,7 +16,8 @@
       "setTopic": "lights/hue/00:17:88:01:02:3c:2a:6d-0b/set/on",
       "getTopic": "hue/status/lights/Hue color lamp 1",
       "onValue": "true",
-      "offValue": "false"
+      "offValue": "false",
+      "icon": "bedroom"
     },
     {
       "name": "Back Light",

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -238,6 +238,9 @@ namespace fs
                 read(device, "setTopic", [&switchDevice] (std::string topic) { switchDevice.setTopic = topic; });
                 read(device, "onValue", [&switchDevice] (std::string value) { switchDevice.onValue = value; });
                 read(device, "offValue", [&switchDevice] (std::string value) { switchDevice.offValue = value; });
+                read(device, "icon", [&switchDevice] (std::optional<std::string> value) {
+                  switchDevice.iconName = value;
+                });
                 devices.push_back({switchDevice.getTopic, std::move(switchDevice)});
                 deviceId += 1;
               }

--- a/main/mqtt/MQTTGroup.hpp
+++ b/main/mqtt/MQTTGroup.hpp
@@ -32,6 +32,7 @@ namespace mqtt
 
     uint16_t deviceId = 0;
     bool active = false;
+    std::optional<std::string> iconName;
     std::function<void()> mSetNeedsUpdateCB;
   };
 

--- a/main/ui/UIDetailButtonBuilder.hpp
+++ b/main/ui/UIDetailButtonBuilder.hpp
@@ -23,8 +23,10 @@ namespace util
       {
         auto button = std::make_shared<UIButton>(&(screen->mTft), Frame(), ptr->groupId);
         button->setBackgroundColor(Color::InactiveBgColor());
-        // TODO use Icons for Devices
-        const auto icons = GetIconFileNames(ptr->iconName);
+
+        // Check if device has icon, else fallback to group icon
+        const bool hasIcon = switchDevice.second.iconName.has_value();
+        const auto icons = hasIcon ? GetIconFileNames(*switchDevice.second.iconName) : GetIconFileNames(ptr->iconName);
 
         button->setLabel(switchDevice.second.name);
         const auto textColor = switchDevice.second.active ? Color::ActiveBgColor() : Color::InactiveTextColor();

--- a/main/ui/UIDetailButtonBuilder.hpp
+++ b/main/ui/UIDetailButtonBuilder.hpp
@@ -19,26 +19,26 @@ namespace util
     {
       std::vector<std::shared_ptr<UIWidget>> buttons;
       auto& context = screen->mpAppContext;
-      for (auto& sensor : ptr->mDevices)
+      for (auto& switchDevice : ptr->mDevices)
       {
         auto button = std::make_shared<UIButton>(&(screen->mTft), Frame(), ptr->groupId);
         button->setBackgroundColor(Color::InactiveBgColor());
         // TODO use Icons for Devices
         const auto icons = GetIconFileNames(ptr->iconName);
 
-        button->setLabel(sensor.second.name);
-        const auto textColor = sensor.second.active ? Color::ActiveBgColor() : Color::InactiveTextColor();
-        const auto imagePath = sensor.second.active ? icons.first : icons.second;
+        button->setLabel(switchDevice.second.name);
+        const auto textColor = switchDevice.second.active ? Color::ActiveBgColor() : Color::InactiveTextColor();
+        const auto imagePath = switchDevice.second.active ? icons.first : icons.second;
         button->setImage(imagePath);
         button->setTextColor(textColor);
         auto groupId = ptr->groupId;
-        auto deviceId = sensor.second.deviceId;
-        button->addTargetAction([groupId, deviceId, &sensor, context](const uint16_t id) {
-          const bool isActive = sensor.second.active;
+        auto deviceId = switchDevice.second.deviceId;
+        button->addTargetAction([groupId, deviceId, &switchDevice, context](const uint16_t id) {
+          const bool isActive = switchDevice.second.active;
           context->getMQTTConnection()->switchDevice(groupId, deviceId, !isActive);
         });
 
-        sensor.second.mSetNeedsUpdateCB = [ptr, deviceId, weakBtn = std::weak_ptr<UIButton>(button), icons]() {
+        switchDevice.second.mSetNeedsUpdateCB = [ptr, deviceId, weakBtn = std::weak_ptr<UIButton>(button), icons]() {
           auto findSensor = std::find_if(ptr->mDevices.begin(), ptr->mDevices.end(), [&deviceId](auto& ele)
           {
             return ele.second.deviceId == deviceId;


### PR DESCRIPTION
Add ability to specify custom Icons for devices within a scene.
If no icon is defined, fall back to group icon.

Closes https://github.com/sieren/Homepoint/issues/137