### PR TITLE
Encode URI-Components of Captive Portal

### DIFF
--- a/data/captive/app.js
+++ b/data/captive/app.js
@@ -3,10 +3,10 @@ function reboot() {
   http.open("POST", "updateConfig.htm", true);
   http.withCredentials = true;
   http.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-  var params = "ssid=" + document.getElementsByName("ssid")[0].value +
-  "&ssidPassword=" + document.getElementsByName("ssidPassword")[0].value +
-  "&loginName=" + document.getElementsByName("loginName")[0].value +
-  "&loginPassword=" + document.getElementsByName("loginPassword")[0].value
+  var params = "ssid=" + encodeURIComponent(document.getElementsByName("ssid")[0].value) +
+  "&ssidPassword=" + encodeURIComponent(document.getElementsByName("ssidPassword")[0].value) +
+  "&loginName=" + encodeURIComponent(document.getElementsByName("loginName")[0].value) +
+  "&loginPassword=" + encodeURIComponent(document.getElementsByName("loginPassword")[0].value)
   http.send(params);
   alert("Homepoint rebooted. Please wait a few seconds and check the new IP on the status bar of the display.");
 }


### PR DESCRIPTION
Correctly encode the post components of the captive form
since some characters might break the form submission.

Closes https://github.com/sieren/Homepoint/issues/151